### PR TITLE
improve import performance (using prepared statement) + NF mode option introduced (expand, normal, crop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ These options affect all files.
 | -RS value | `-RS '\n'` | Input record separator for the default parser (one for all input files). |
 | -OFS value | `-OFS ' '` | Output field separator for the default serializer. |
 | -ORS value | `-ORS '\n'` | Output record separator for the default serializer. |
-| -NF value | `-NF 10` | The maximum number of fields per record. Increase this if you get errors like `table x has no column named x51`. |
+| -NF value | `-NF 10` | The maximum number of fields per record. Increase this if you get errors like `table x has no column named x51` (`MNF=normal` only). |
+| -MNF value | `-MNF expand`, `-MNF crop`, `-MNF normal` | NF mode, used if record exceed maximum number of fields:  `expand` - automatically enlarge `NF` and expand (alter) table during import if record contains more fields; `crop` - truncate record to `NF` value (fields exceed a `NF` value will be not imported); `normal` - produce an error like `table x has no column named x11` if record contains more fields. |
 | -output value | `-output awk`, `-output csv` | The output format. Currently can be `awk` (the default) `csv` or `tcl`. The `awk` serializer behaves similarly to Awk. When it is selected Sqawk outputs each column of each of the database rows returned by your query separated from the next with the output field separator (-OFS); the rows themselves are in turn separated with the output record separator (-ORS). |
 | -v | | Print the Sqawk version and exit. |
 | -1 | | Do not split records into fields. Same as `-F '^$'`. Allows you to avoid adjusting `-NF` and improves the performance somewhat for when you only want to operate on lines. |
@@ -67,6 +68,7 @@ These options are set before a filename and only affect one input source.
 | prefix | `prefix=x` | Column name prefix in the table. Defaults to the table name. Specifying `table=foo` and `prefix=bar` will lead to you being able to use queries like `select bar1, bar2 from foo`.  |
 | table | `table=foo` | Table name. By default tables are named `a`, `b`, `c`, ... Specifying `table=foo` for the second file only will result in tables having the names `a`, `foo`, `c`, ...  |
 | NF | `NF=20` | Same as -NF but for one file. |
+| MNF | `MNF=crop` | Same as -MNF but for one file (table). |
 
 ### Input format options
 

--- a/lib/classes/sqawk.tcl
+++ b/lib/classes/sqawk.tcl
@@ -120,7 +120,8 @@ namespace eval ::sqawk {}
                 -database [$self cget -database] \
                 -dbtable $metadata(table) \
                 -columnprefix $metadata(prefix) \
-                -maxnf $metadata(NF)
+                -maxnf $metadata(NF) \
+                -modenf $metadata(MNF)
         if {[info exists metadata(header)] && $metadata(header)} {
             # Remove the first field (a0/b0/...) from the header.
             set header [lrange [lindex [::sqawk::lshift! rows] 0] 1 end]

--- a/lib/classes/table.tcl
+++ b/lib/classes/table.tcl
@@ -10,6 +10,7 @@ namespace eval ::sqawk {}
     option -dbtable
     option -columnprefix
     option -maxnf
+    option -modenf {}
     option -header {}
 
     destructor {
@@ -52,35 +53,56 @@ namespace eval ::sqawk {}
         set colPrefix [$self cget -columnprefix]
         set tableName [$self cget -dbtable]
 
-        set commands {}
-
-        set rowInsertCommand {
-            INSERT INTO $tableName ($insertColumnNames)
-            VALUES ($insertValues)
-        }
-
         set maxNF [$self cget -maxnf]
-        for {set i 0} {$i <= $maxNF} {incr i} {
-            set columnNames($i) [$self column-name $i]
+        set modeNF [$self cget -modenf]
+        set curNF 0
+        set insertColumnNames [list "${colPrefix}nf"]
+        set insertValues [list {$nf}]
+
+        set sub_rowInsertCommand {
+            # prepare statement (column names / variables for binding):
+            if {$curNF < $nf} {
+                set i $curNF
+                while {$i < $nf} {
+                    lappend insertColumnNames [$self column-name $i]
+                    lappend insertValues "\$cv($i)"
+                    incr i
+                }
+            } else {
+                set insertColumnNames [lrange $insertColumnNames 0 $nf]
+                set insertValues [lrange $insertValues 0 $nf]
+            }
+            # expand (alter) table if needed:
+            if {$modeNF eq "expand" && $nf - 1 > $maxNF} {
+                for {set i $maxNF; incr i} {$i < $nf} {incr i} {
+                  $db eval "ALTER TABLE $tableName ADD COLUMN [$self column-name $i] INTEGER"
+                }
+                $self configure -maxnf [set maxNF [incr i -1]]
+            }
+            set curNF $nf
+            # create prepared statement (will be cached by "eval"):
+            set stat [set rowInsertCommand($curNF) "
+            INSERT INTO $tableName ([join $insertColumnNames ,])
+            VALUES ([join $insertValues ,])
+            "]
         }
 
         $db transaction {
             foreach row $rows {
                 set nf [llength $row]
-                set insertColumnNames "${colPrefix}nf,"
-                set insertValues {$nf,}
+                # crop (truncate row) if needed:
+                if {$modeNF eq "crop" && $nf >= $maxNF} {
+                    set nf [llength [set row [lrange $row 0 $maxNF]]]
+                }
+                # first prepare or if current row contains more fields as created - alter table (expand columns):
+                if {$nf != $curNF && [catch {set stat $rowInsertCommand($nf)}]} $sub_rowInsertCommand
+                # bind - set fileds to variables array:
                 set i 0
                 foreach field $row {
-                    set $columnNames($i) $field
-                    append insertColumnNames $columnNames($i)
-                    append insertValues "\$$columnNames($i)"
-                    if {$i < ($nf - 1)} {
-                        append insertColumnNames ,
-                        append insertValues ,
-                    }
+                    set cv($i) $field
                     incr i
                 }
-                $db eval [subst $rowInsertCommand]
+                $db eval $stat
             }
         }
     }

--- a/sqawk-dev.tcl
+++ b/sqawk-dev.tcl
@@ -39,6 +39,7 @@ proc ::sqawk::script::process-options {argv} {
         {OFS.arg { } "Output field separator"}
         {ORS.arg {\n} "Output record separator"}
         {NF.arg 10 "Maximum NF value for all files"}
+        {MNF.arg {expand} "NF mode (expand, normal or crop)"}
         {output.arg {awk} "Output format"}
         {v "Print version"}
         {1 "One field only. A shortcut for -FS '^$'"}
@@ -76,7 +77,7 @@ proc ::sqawk::script::process-options {argv} {
     set fileCount 0
     set fileOptionsForAllFiles {}
     set defaultFileOptions [::sqawk::filter-keys $cmdOptions {
-        FS RS NF
+        FS RS NF MNF
     }]
     set currentFileOptions $defaultFileOptions
     while {[llength $argv] > 0} {


### PR DESCRIPTION
- prepared statement handles will be cached inside tcl-sqlite:eval using the same unchanged statement, so import of large resp. wide rows runs significant faster now;
- because of automatically growing of table (`MNF` default value is `expand`) we could set default value of `NF` to `0`, but it would be a little bit backwards incompatible (each table had early always at least 10 columns), so I have left it unchanged;
- test cases extended to test all three modes of `MNF` and to test using of prepared statement.
