### PR TITLE
new option `IMPF`: importable fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ These options affect all files.
 | -ORS value | `-ORS '\n'` | Output record separator for the default serializer. |
 | -NF value | `-NF 10` | The maximum number of fields per record. Increase this if you get errors like `table x has no column named x51` (`MNF=normal` only). |
 | -MNF value | `-MNF expand`, `-MNF crop`, `-MNF normal` | The NF mode used if a record exceed the maximum number of fields: `expand` means to increase `NF` automatically and expand (alter) the table during import if the record contains more fields than available; `crop` means truncate the record to `NF` fields (fields after that will be not imported); `normal` makes Sqawk produce an error like `table x has no column named x11`. |
+| -IMPF value | `-IMPF nr,nf,0-`, `-IMPF 1-2` | Fields to be imported into the table (default `nr,nf,0-`). The last value should be a numeric indices (from?-?to??). Can be used to exact specifying which fields should be imported from input. (increases import performance, minimizes overhead and simplifies output of statements like `select * from a`, if e. g. fields like `anr`, `anf` and `a0` are not necessary or too many input fields available). |
 | -output value | `-output awk` | The output format. See [Output formats](#output-formats). |
 | -v | | Print the Sqawk version and exit. |
 | -1 | | Do not split records into fields. Same as `-F '^$'`. Allows you to avoid adjusting `-NF` and improves the performance somewhat for when you only want to operate on lines. |
@@ -86,6 +87,7 @@ These options are set before a filename and only affect one input source.
 | table | `table=foo` | Table name. By default tables are named `a`, `b`, `c`, ... Specifying `table=foo` for the second file only will result in tables having the names `a`, `foo`, `c`, ...  |
 | NF | `NF=20` | Same as -NF but for one file. |
 | MNF | `MNF=crop` | Same as -MNF but for one file (table). |
+| IMPF | `IMPF=nr,nf,0-`, `IMPF=nr,2-5` | Importable fields, same as -IMPF but for one file (table). |
 
 #### Input formats
 

--- a/sqawk-dev.tcl
+++ b/sqawk-dev.tcl
@@ -46,6 +46,7 @@ proc ::sqawk::script::process-options {argv} {
         {ORS.arg {\n} "Output record separator"}
         {NF.arg 10 "Maximum NF value for all files"}
         {MNF.arg {expand} "NF mode (expand, normal or crop)"}
+        {IMPF.arg {nr,nf,0-} "Importable fields into table (default 'nr,nf,0-')"}
         {output.arg {awk} "Output format"}
         {v "Print version"}
         {1 "One field only. A shortcut for -FS '^$'"}
@@ -83,7 +84,7 @@ proc ::sqawk::script::process-options {argv} {
     set fileCount 0
     set fileOptionsForAllFiles {}
     set defaultFileOptions [::sqawk::filter-keys $cmdOptions {
-        FS RS NF MNF
+        FS RS NF MNF IMPF
     }]
     set currentFileOptions $defaultFileOptions
     while {[llength $argv] > 0} {

--- a/tests.tcl
+++ b/tests.tcl
@@ -618,6 +618,54 @@ namespace eval ::sqawk::tests {
     } -result \
         {{1 5 {A B C D} A B C D} {2 4 {A B C} A B C {}} {3 3 {A B} A B {} {}}}
 
+    tcltest::test nf-2.4 {IMPF test} \
+            -setup $setup \
+            -body {
+        variable nf2File
+        sqawk-tcl \
+                -FS " " \
+                -IMPF "1-4" \
+                -output tcl \
+                {select * from a} $nf2File
+    } -result \
+        {{A B C D} {A B C {}} {A B {} {}}}
+
+    tcltest::test nf-2.5 {IMPF test} \
+            -setup $setup \
+            -body {
+        variable nf2File
+        sqawk-tcl \
+                -FS " " \
+                -IMPF "2-3" \
+                -output tcl \
+                {select * from a} $nf2File
+    } -result \
+        {{B C} {B C} {B {}}}
+
+    tcltest::test nf-2.6 {IMPF test} \
+            -setup $setup \
+            -body {
+        variable nf2File
+        sqawk-tcl \
+                -FS " " \
+                -IMPF "2" \
+                -output tcl \
+                {select * from a} $nf2File
+    } -result \
+        {B B B}
+
+    tcltest::test nf-2.7 {IMPF test} \
+            -setup $setup \
+            -body {
+        variable nf2File
+        sqawk-tcl \
+                -FS " " \
+                -output json \
+                {select a.*, b.* from a inner join b on anr = bnr limit 2} \
+                IMPF=nr,1 $nf2File IMPF=nr,2-3 $nf2File
+    } -result \
+        {[{"anr":"1","a1":"A","bnr":"1","b2":"B","b3":"C"},{"anr":"2","a1":"A","bnr":"2","b2":"B","b3":"C"}]}
+
     tcltest::test nf-3.1 {NF mode expand} \
             -setup $setup \
             -body {


### PR DESCRIPTION
new option `IMPF` introduced: describes fields to be imported into the table(s), default `nr,nf,0-`), can be used to exact specifying which fields should be imported from input (increases import performance, minimizes overhead and simplifies output of statements like `select * from a`, if e. g. fields like `anr`, `anf` and `a0` are not necessary or too many input fields available).

Examples:

``` bash
# with `-IMPF nr,1-2` - select anr, a1, a2 only:
echo -e "A B C D\nA B C\nA B" | sqawk -FS " " -IMPF nr,1-2 -output json "select * from a"

[{"anr":"1","a1":"A","a2":"B"},{"anr":"2","a1":"A","a2":"B"},{"anr":"3","a1":"A","a2":"B"}]

# without `-IMPF` - select anr, anf, a0 (whole record) and 10 fieds (default):
echo -e "A B C D\nA B C\nA B" | sqawk -FS " " -output json "select * from a"

[{"anr":"1","anf":"5","a0":"A B C D","a1":"A","a2":"B","a3":"C","a4":"D","a5":"","a6":"","a7":"","a8":"","a9":"","a10":""},{"anr":"2","anf":"4","a0":"A B C","a1":"A","a2":"B","a3":"C","a4":"","a5":"","a6":"","a7":"","a8":"","a9":"","a10":""},{"anr":"3","anf":"3","a0":"A B","a1":"A","a2":"B","a3":"","a4":"","a5":"","a6":"","a7":"","a8":"","a9":"","a10":""}]
```
